### PR TITLE
Fixed evaluateSPQRSolverDeterminedSystem : x has kNumVariables many entries.

### DIFF
--- a/incremental_calibration/test/LinearSolverTest.cpp
+++ b/incremental_calibration/test/LinearSolverTest.cpp
@@ -161,7 +161,7 @@ void evaluateSPQRSolverDeterminedSystem(const aslam::calibration::LinearSolverOp
 
 
     EXPECT_EQ(solver.getCovariance(), Eigen::MatrixXd::Identity(num_calib_vars, num_calib_vars));
-    EXPECT_EQ(x, Eigen::VectorXd::Constant(num_calib_vars, kXResult));
+    EXPECT_EQ(x, Eigen::VectorXd::Constant(kNumVariables, kXResult));
   }
 }
 


### PR DESCRIPTION
At least this seems to be the case... I don't get why this was green before ... (my Eigen is complaining about the former comparison of two differently sized vectors). 
