### PR TITLE
Removed remaining traces of the former LGPL license

### DIFF
--- a/incremental_calibration/include/aslam/calibration/algorithms/matrixOperations.h
+++ b/incremental_calibration/include/aslam/calibration/algorithms/matrixOperations.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file matrixOperations.h

--- a/incremental_calibration/include/aslam/calibration/algorithms/matrixOperations.tpp
+++ b/incremental_calibration/include/aslam/calibration/algorithms/matrixOperations.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/OutOfBoundException.h"

--- a/incremental_calibration/include/aslam/calibration/algorithms/permute.h
+++ b/incremental_calibration/include/aslam/calibration/algorithms/permute.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file permute.h

--- a/incremental_calibration/include/aslam/calibration/algorithms/permute.tpp
+++ b/incremental_calibration/include/aslam/calibration/algorithms/permute.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/OutOfBoundException.h"

--- a/incremental_calibration/include/aslam/calibration/base/Serializable.h
+++ b/incremental_calibration/include/aslam/calibration/base/Serializable.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Serializable.h

--- a/incremental_calibration/include/aslam/calibration/base/Singleton.tpp
+++ b/incremental_calibration/include/aslam/calibration/base/Singleton.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/InvalidOperationException.h"

--- a/incremental_calibration/include/aslam/calibration/base/Timestamp.h
+++ b/incremental_calibration/include/aslam/calibration/base/Timestamp.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Timestamp.h

--- a/incremental_calibration/include/aslam/calibration/core/IncrementalEstimator.h
+++ b/incremental_calibration/include/aslam/calibration/core/IncrementalEstimator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncrementalEstimator.h

--- a/incremental_calibration/include/aslam/calibration/core/IncrementalOptimizationProblem.h
+++ b/incremental_calibration/include/aslam/calibration/core/IncrementalOptimizationProblem.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncrementalOptimizationProblem.h

--- a/incremental_calibration/include/aslam/calibration/core/OptimizationProblem.h
+++ b/incremental_calibration/include/aslam/calibration/core/OptimizationProblem.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblem.h

--- a/incremental_calibration/include/aslam/calibration/data-structures/Grid.h
+++ b/incremental_calibration/include/aslam/calibration/data-structures/Grid.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Grid.h

--- a/incremental_calibration/include/aslam/calibration/data-structures/Grid.tpp
+++ b/incremental_calibration/include/aslam/calibration/data-structures/Grid.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/OutOfBoundException.h"

--- a/incremental_calibration/include/aslam/calibration/data-structures/VectorDesignVariable.h
+++ b/incremental_calibration/include/aslam/calibration/data-structures/VectorDesignVariable.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file VectorDesignVariable.h

--- a/incremental_calibration/include/aslam/calibration/data-structures/VectorDesignVariable.tpp
+++ b/incremental_calibration/include/aslam/calibration/data-structures/VectorDesignVariable.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/OutOfBoundException.h"

--- a/incremental_calibration/include/aslam/calibration/exceptions/BadArgumentException.h
+++ b/incremental_calibration/include/aslam/calibration/exceptions/BadArgumentException.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file BadArgumentException.h

--- a/incremental_calibration/include/aslam/calibration/exceptions/Exception.h
+++ b/incremental_calibration/include/aslam/calibration/exceptions/Exception.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Exception.h

--- a/incremental_calibration/include/aslam/calibration/exceptions/InvalidOperationException.h
+++ b/incremental_calibration/include/aslam/calibration/exceptions/InvalidOperationException.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file InvalidOperationException.h

--- a/incremental_calibration/include/aslam/calibration/exceptions/NullPointerException.h
+++ b/incremental_calibration/include/aslam/calibration/exceptions/NullPointerException.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file NullPointerException.h

--- a/incremental_calibration/include/aslam/calibration/exceptions/OutOfBoundException.h
+++ b/incremental_calibration/include/aslam/calibration/exceptions/OutOfBoundException.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OutOfBoundException.h

--- a/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction1v.h
+++ b/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousFunction1v.h

--- a/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/ContinuousFunction1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/functions/ContinuousFunctionMv.h
+++ b/incremental_calibration/include/aslam/calibration/functions/ContinuousFunctionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousFunctionMv.h

--- a/incremental_calibration/include/aslam/calibration/functions/ContinuousFunctionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/ContinuousFunctionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/functions/DigammaFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/DigammaFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DigammaFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/DigammaFunction.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/DigammaFunction.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <boost/math/special_functions/digamma.hpp>

--- a/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction1v.h
+++ b/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteFunction1v.h

--- a/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/DiscreteFunction1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/functions/DiscreteFunctionMv.h
+++ b/incremental_calibration/include/aslam/calibration/functions/DiscreteFunctionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteFunctionMv.h

--- a/incremental_calibration/include/aslam/calibration/functions/DiscreteFunctionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/DiscreteFunctionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/functions/Function.h
+++ b/incremental_calibration/include/aslam/calibration/functions/Function.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Function.h

--- a/incremental_calibration/include/aslam/calibration/functions/Function.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/Function.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/functions/IncompleteGammaPFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/IncompleteGammaPFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncompleteGammaPFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/IncompleteGammaQFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/IncompleteGammaQFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncompleteGammaQFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/LogFactorialFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/LogFactorialFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file LogFactorialFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/LogGammaFunction.h
+++ b/incremental_calibration/include/aslam/calibration/functions/LogGammaFunction.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file LogGammaFunction.h

--- a/incremental_calibration/include/aslam/calibration/functions/LogGammaFunction.tpp
+++ b/incremental_calibration/include/aslam/calibration/functions/LogGammaFunction.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <cmath>

--- a/incremental_calibration/include/aslam/calibration/geometry/Transformation.h
+++ b/incremental_calibration/include/aslam/calibration/geometry/Transformation.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Transformation.h

--- a/incremental_calibration/include/aslam/calibration/geometry/Transformation2d.h
+++ b/incremental_calibration/include/aslam/calibration/geometry/Transformation2d.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Transformation2d.h

--- a/incremental_calibration/include/aslam/calibration/geometry/Transformation2d.tpp
+++ b/incremental_calibration/include/aslam/calibration/geometry/Transformation2d.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <cmath>

--- a/incremental_calibration/include/aslam/calibration/geometry/Transformation3d.h
+++ b/incremental_calibration/include/aslam/calibration/geometry/Transformation3d.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Transformation3d.h

--- a/incremental_calibration/include/aslam/calibration/geometry/Transformation3d.tpp
+++ b/incremental_calibration/include/aslam/calibration/geometry/Transformation3d.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/ChiSquareDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/ChiSquareDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ChiSquareDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousDistribution1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistribution1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistributionMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistributionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ContinuousDistributionMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistributionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/ContinuousDistributionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteDistribution1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistribution1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistributionMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistributionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DiscreteDistributionMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistributionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/DiscreteDistributionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/Distribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/Distribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Distribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/Distribution.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/Distribution.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/EstimatorML.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/EstimatorML.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file EstimatorML.h

--- a/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormal1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormal1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file EstimatorMLNormal1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormalMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormalMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file EstimatorMLNormalMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormalMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/EstimatorMLNormalMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/utils/OuterProduct.h"

--- a/incremental_calibration/include/aslam/calibration/statistics/GammaDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/GammaDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file GammaDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/GammaDistribution.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/GammaDistribution.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <boost/math/distributions/gamma.hpp>

--- a/incremental_calibration/include/aslam/calibration/statistics/Histogram.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/Histogram.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Histogram.h

--- a/incremental_calibration/include/aslam/calibration/statistics/Histogram1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/Histogram1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Histogram1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/Histogram1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/Histogram1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <limits>

--- a/incremental_calibration/include/aslam/calibration/statistics/HistogramMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/HistogramMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file HistogramMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/HistogramMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/HistogramMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <limits>

--- a/incremental_calibration/include/aslam/calibration/statistics/NormalDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/NormalDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file NormalDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/NormalDistribution1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/NormalDistribution1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file NormalDistribution1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/NormalDistributionMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/NormalDistributionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file NormalDistributionMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/NormalDistributionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/NormalDistributionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include <Eigen/LU>

--- a/incremental_calibration/include/aslam/calibration/statistics/Randomizer.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/Randomizer.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Randomizer.h

--- a/incremental_calibration/include/aslam/calibration/statistics/Randomizer.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/Randomizer.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/base/Timestamp.h"

--- a/incremental_calibration/include/aslam/calibration/statistics/SampleDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/SampleDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SampleDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/SampleDistribution.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/SampleDistribution.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace aslam {

--- a/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file UniformDistribution.h

--- a/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution1v.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution1v.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file UniformDistribution1v.h

--- a/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution1v.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/UniformDistribution1v.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/statistics/Randomizer.h"

--- a/incremental_calibration/include/aslam/calibration/statistics/UniformDistributionMv.h
+++ b/incremental_calibration/include/aslam/calibration/statistics/UniformDistributionMv.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the               *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file UniformDistributionMv.h

--- a/incremental_calibration/include/aslam/calibration/statistics/UniformDistributionMv.tpp
+++ b/incremental_calibration/include/aslam/calibration/statistics/UniformDistributionMv.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/statistics/Randomizer.h"

--- a/incremental_calibration/include/aslam/calibration/tpl/And.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/And.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file And.h

--- a/incremental_calibration/include/aslam/calibration/tpl/Boolean.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/Boolean.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Boolean.h

--- a/incremental_calibration/include/aslam/calibration/tpl/Equals.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/Equals.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Equals.h

--- a/incremental_calibration/include/aslam/calibration/tpl/If.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/If.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file If.h

--- a/incremental_calibration/include/aslam/calibration/tpl/IfThenElse.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/IfThenElse.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IfThenElse.h

--- a/incremental_calibration/include/aslam/calibration/tpl/IsInteger.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/IsInteger.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IsInteger.h

--- a/incremental_calibration/include/aslam/calibration/tpl/IsNumeric.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/IsNumeric.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IsNumeric.h

--- a/incremental_calibration/include/aslam/calibration/tpl/IsReal.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/IsReal.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IsReal.h

--- a/incremental_calibration/include/aslam/calibration/tpl/IsVoid.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/IsVoid.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IsVoid.h

--- a/incremental_calibration/include/aslam/calibration/tpl/Not.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/Not.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Not.h

--- a/incremental_calibration/include/aslam/calibration/tpl/Or.h
+++ b/incremental_calibration/include/aslam/calibration/tpl/Or.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Or.h

--- a/incremental_calibration/include/aslam/calibration/utils/OuterProduct.h
+++ b/incremental_calibration/include/aslam/calibration/utils/OuterProduct.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OuterProduct.h

--- a/incremental_calibration/include/aslam/calibration/utils/OuterProduct.tpp
+++ b/incremental_calibration/include/aslam/calibration/utils/OuterProduct.tpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2011 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 namespace OuterProduct {

--- a/incremental_calibration/include/aslam/calibration/utils/SizeTSupport.h
+++ b/incremental_calibration/include/aslam/calibration/utils/SizeTSupport.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SizeTSupport.h

--- a/incremental_calibration/include/aslam/calibration/utils/SsizeTSupport.h
+++ b/incremental_calibration/include/aslam/calibration/utils/SsizeTSupport.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SsizeTSupport.h

--- a/incremental_calibration/src/base/Serializable.cpp
+++ b/incremental_calibration/src/base/Serializable.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/base/Serializable.h"

--- a/incremental_calibration/src/base/Timestamp.cpp
+++ b/incremental_calibration/src/base/Timestamp.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/base/Timestamp.h"

--- a/incremental_calibration/src/core/IncrementalEstimator.cpp
+++ b/incremental_calibration/src/core/IncrementalEstimator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/core/IncrementalEstimator.h"

--- a/incremental_calibration/src/core/IncrementalOptimizationProblem.cpp
+++ b/incremental_calibration/src/core/IncrementalOptimizationProblem.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/core/IncrementalOptimizationProblem.h"

--- a/incremental_calibration/src/core/OptimizationProblem.cpp
+++ b/incremental_calibration/src/core/OptimizationProblem.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/core/OptimizationProblem.h"

--- a/incremental_calibration/src/exceptions/Exception.cpp
+++ b/incremental_calibration/src/exceptions/Exception.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/Exception.h"

--- a/incremental_calibration/src/exceptions/InvalidOperationException.cpp
+++ b/incremental_calibration/src/exceptions/InvalidOperationException.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/InvalidOperationException.h"

--- a/incremental_calibration/src/exceptions/NullPointerException.cpp
+++ b/incremental_calibration/src/exceptions/NullPointerException.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/exceptions/NullPointerException.h"

--- a/incremental_calibration/src/functions/IncompleteGammaPFunction.cpp
+++ b/incremental_calibration/src/functions/IncompleteGammaPFunction.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/functions/IncompleteGammaPFunction.h"

--- a/incremental_calibration/src/functions/IncompleteGammaQFunction.cpp
+++ b/incremental_calibration/src/functions/IncompleteGammaQFunction.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/functions/IncompleteGammaQFunction.h"

--- a/incremental_calibration/src/functions/LogFactorialFunction.cpp
+++ b/incremental_calibration/src/functions/LogFactorialFunction.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/functions/LogFactorialFunction.h"

--- a/incremental_calibration/src/functions/LogGammaFunction.cpp
+++ b/incremental_calibration/src/functions/LogGammaFunction.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/functions/LogGammaFunction.h"

--- a/incremental_calibration/src/statistics/ChiSquareDistribution.cpp
+++ b/incremental_calibration/src/statistics/ChiSquareDistribution.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/statistics/ChiSquareDistribution.h"

--- a/incremental_calibration/src/statistics/EstimatorMLNormal1v.cpp
+++ b/incremental_calibration/src/statistics/EstimatorMLNormal1v.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/statistics/EstimatorML.h"

--- a/incremental_calibration/src/statistics/NormalDistribution1v.cpp
+++ b/incremental_calibration/src/statistics/NormalDistribution1v.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/statistics/NormalDistribution.h"

--- a/incremental_calibration/test/IncrementalOptimizationProblemTest.cpp
+++ b/incremental_calibration/test/IncrementalOptimizationProblemTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncrementalOptimizationProblemTest.cpp

--- a/incremental_calibration/test/OptimizationProblemTest.cpp
+++ b/incremental_calibration/test/OptimizationProblemTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblemTest.cpp

--- a/incremental_calibration/test/VectorDesignVariableTest.cpp
+++ b/incremental_calibration/test/VectorDesignVariableTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file VectorDesignVariableTest.cpp

--- a/incremental_calibration/test/test_main.cpp
+++ b/incremental_calibration/test/test_main.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file test_main.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/ErrorTermMotion.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/ErrorTermMotion.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermMotion.h

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/ErrorTermObservation.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/ErrorTermObservation.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermObservation.h

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/utils.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/include/aslam/calibration/2dlrf/utils.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file utils.h

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/ErrorTermMotion.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/ErrorTermMotion.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/2dlrf/ErrorTermMotion.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/ErrorTermObservation.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/ErrorTermObservation.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/2dlrf/ErrorTermObservation.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-offline.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-offline.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulate-offline.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-online-new.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-online-new.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulate-online-new.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-online.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/simulate-online.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulate-online.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/utils.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/src/2dlrf/utils.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/2dlrf/utils.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/ErrorTermMotionTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/ErrorTermMotionTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermMotionTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/ErrorTermObservationTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/ErrorTermObservationTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermObservationTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/test_main.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_2dlrf/test/test_main.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file test_main.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/include/aslam/calibration/camera/CameraCalibrator.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/include/aslam/calibration/camera/CameraCalibrator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CameraCalibrator.h

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/include/aslam/calibration/camera/CameraValidator.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/include/aslam/calibration/camera/CameraValidator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CameraValidator.h

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/CameraCalibrator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/CameraCalibrator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/camera/CameraCalibrator.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/CameraValidator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/CameraValidator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/camera/CameraValidator.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/calibrateCamera.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/calibrateCamera.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file calibrateCamera.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/validateCamera.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_camera/src/camera/validateCamera.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file validateCamera.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/CarCalibrator.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/CarCalibrator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CarCalibrator.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/CarCalibratorOptions.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/CarCalibratorOptions.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CarCalibratorOptions.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/OptimizationProblemSpline.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/OptimizationProblemSpline.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblemSpline.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/bestQuat.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/bestQuat.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file bestQuat.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/splinesToFile.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/algo/splinesToFile.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file splinesToFile.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/DMIMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/DMIMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DMIMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/MeasurementsContainer.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/MeasurementsContainer.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file MeasurementsContainer.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/PoseMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/PoseMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file PoseMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/SteeringMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/SteeringMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SteeringMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/VelocitiesMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/VelocitiesMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file VelocitiesMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/WheelSpeedsMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/data/WheelSpeedsMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file WheelSpeedsMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/design-variables/OdometryDesignVariables.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/design-variables/OdometryDesignVariables.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OdometryDesignVariables.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermPose.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermPose.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermPose.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermSteering.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermSteering.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermSteering.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermVelocities.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermVelocities.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermVelocities.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermWheel.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/error-terms/ErrorTermWheel.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermWheel.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/geo/geodetic.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/include/aslam/calibration/car/geo/geodetic.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file geodetic.h

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/CarCalibrator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/CarCalibrator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/algo/CarCalibrator.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/CarCalibratorOptions.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/CarCalibratorOptions.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/algo/CarCalibratorOptions.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/OptimizationProblemSpline.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/OptimizationProblemSpline.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/algo/OptimizationProblemSpline.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/bestQuat.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/bestQuat.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/algo/bestQuat.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/splinesToFile.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/algo/splinesToFile.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/algo/splinesToFile.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/design-variables/OdometryDesignVariables.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/design-variables/OdometryDesignVariables.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/design-variables/OdometryDesignVariables.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermPose.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermPose.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/error-terms/ErrorTermPose.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermSteering.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermSteering.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/error-terms/ErrorTermSteering.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermVelocities.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermVelocities.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/error-terms/ErrorTermVelocities.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermWheel.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/error-terms/ErrorTermWheel.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/error-terms/ErrorTermWheel.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/geo/geodetic.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/geo/geodetic.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/car/geo/geodetic.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/realworld/analyzer.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/realworld/analyzer.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file analyzer.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/src/realworld/calibrator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/src/realworld/calibrator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file calibrator.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermPoseTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermPoseTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermPoseTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermSteeringTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermSteeringTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermWheelTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermVelocitiesTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermVelocitiesTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermVelocitiesTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermWheelTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/test/error-terms/ErrorTermWheelTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermWheelTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_car/test/test_main.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_car/test/test_main.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file test_main.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/Calibrator.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/Calibrator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Calibrator.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/CalibratorOptions.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/CalibratorOptions.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CalibratorOptions.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/OptimizationProblemSpline.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/OptimizationProblemSpline.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblemSpline.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/bestQuat.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/bestQuat.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file bestQuat.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/splinesToFile.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/algo/splinesToFile.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file splinesToFile.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/data/MeasurementsContainer.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/data/MeasurementsContainer.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file MeasurementsContainer.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/data/MotionMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/data/MotionMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file MotionMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/design-variables/DesignVariables.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/design-variables/DesignVariables.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file DesignVariables.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/SimulationData.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/SimulationData.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SimulationData.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/SimulationParams.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/SimulationParams.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SimulationParams.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/Trajectory.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/Trajectory.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Trajectory.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/TrajectoryParams.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/TrajectoryParams.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file TrajectoryParams.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/simulationEngine.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/include/aslam/calibration/egomotion/simulation/simulationEngine.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulationEngine.h

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/Calibrator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/Calibrator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/algo/Calibrator.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/CalibratorOptions.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/CalibratorOptions.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/algo/CalibratorOptions.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/OptimizationProblemSpline.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/OptimizationProblemSpline.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/algo/OptimizationProblemSpline.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/bestQuat.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/bestQuat.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/algo/bestQuat.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/splinesToFile.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/algo/splinesToFile.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/algo/splinesToFile.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/design-variables/DesignVariables.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/design-variables/DesignVariables.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/design-variables/DesignVariables.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/SimulationParams.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/SimulationParams.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/simulation/SimulationParams.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/TrajectoryParams.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/TrajectoryParams.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/simulation/TrajectoryParams.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/simulationEngine.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/simulationEngine.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/egomotion/simulation/simulationEngine.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/simulator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_egomotion_sensors/src/simulation/simulator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2015 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulator.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/Calibrator.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/Calibrator.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Calibrator.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/CalibratorOptions.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/CalibratorOptions.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file CalibratorOptions.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/OptimizationProblemSpline.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/OptimizationProblemSpline.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblemSpline.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/bestQuat.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/bestQuat.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file bestQuat.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/splinesToFile.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/algo/splinesToFile.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file splinesToFile.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/MeasurementsContainer.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/MeasurementsContainer.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file MeasurementsContainer.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/PoseMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/PoseMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file PoseMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/WheelSpeedMeasurement.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/data/WheelSpeedMeasurement.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file WheelSpeedsMeasurement.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/design-variables/OdometryDesignVariables.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/design-variables/OdometryDesignVariables.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OdometryDesignVariables.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/error-terms/ErrorTermPose.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/error-terms/ErrorTermPose.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermPose.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/error-terms/ErrorTermWheel.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/error-terms/ErrorTermWheel.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermWheel.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/SimulationData.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/SimulationData.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SimulationData.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/SimulationParams.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/SimulationParams.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file SimulationParams.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/Trajectory.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/Trajectory.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file Trajectory.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/TrajectoryParams.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/TrajectoryParams.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file TrajectoryParams.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/simulationEngine.h
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/include/aslam/calibration/time-delay/simulation/simulationEngine.h
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulationEngine.h

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/Calibrator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/Calibrator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/algo/Calibrator.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/CalibratorOptions.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/CalibratorOptions.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/algo/CalibratorOptions.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/OptimizationProblemSpline.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/OptimizationProblemSpline.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/algo/OptimizationProblemSpline.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/bestQuat.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/bestQuat.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/algo/bestQuat.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/splinesToFile.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/algo/splinesToFile.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/algo/splinesToFile.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/design-variables/OdometryDesignVariables.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/design-variables/OdometryDesignVariables.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/design-variables/OdometryDesignVariables.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/error-terms/ErrorTermPose.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/error-terms/ErrorTermPose.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/error-terms/ErrorTermPose.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/error-terms/ErrorTermWheel.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/error-terms/ErrorTermWheel.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/error-terms/ErrorTermWheel.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/SimulationData.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/SimulationData.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/simulation/SimulationData.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/SimulationParams.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/SimulationParams.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/simulation/SimulationParams.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/Trajectory.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/Trajectory.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/simulation/Trajectory.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/TrajectoryParams.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/TrajectoryParams.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/simulation/TrajectoryParams.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/simulationEngine.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/simulationEngine.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 #include "aslam/calibration/time-delay/simulation/simulationEngine.h"

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/simulator.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/src/simulation/simulator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file simulator.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/error-terms/ErrorTermPoseTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/error-terms/ErrorTermPoseTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermPoseTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/error-terms/ErrorTermWheelTest.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/error-terms/ErrorTermWheelTest.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file ErrorTermWheelTest.cpp

--- a/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/test_main.cpp
+++ b/incremental_calibration_examples/incremental_calibration_examples_time_delay/test/test_main.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2014 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file test_main.cpp

--- a/incremental_calibration_python/src/IncrementalEstimator.cpp
+++ b/incremental_calibration_python/src/IncrementalEstimator.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Paul Furgale and Jerome Maye                         *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file IncrementalEstimator.cpp

--- a/incremental_calibration_python/src/LinearSolver.cpp
+++ b/incremental_calibration_python/src/LinearSolver.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Jerome Maye                                          *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file LinearSolver.cpp

--- a/incremental_calibration_python/src/OptimizationProblem.cpp
+++ b/incremental_calibration_python/src/OptimizationProblem.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Paul Furgale and Jerome Maye                         *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file OptimizationProblem.cpp

--- a/incremental_calibration_python/src/module.cpp
+++ b/incremental_calibration_python/src/module.cpp
@@ -1,19 +1,6 @@
 /******************************************************************************
  * Copyright (C) 2013 by Paul Furgale and Jerome Maye                         *
  * jerome.maye@gmail.com                                                      *
- *                                                                            *
- * This program is free software; you can redistribute it and/or modify       *
- * it under the terms of the Lesser GNU General Public License as published by*
- * the Free Software Foundation; either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- *                                                                            *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * Lesser GNU General Public License for more details.                        *
- *                                                                            *
- * You should have received a copy of the Lesser GNU General Public License   *
- * along with this program. If not, see <http://www.gnu.org/licenses/>.       *
  ******************************************************************************/
 
 /** \file module.cpp

--- a/incremental_calibration_vision/manifest.xml
+++ b/incremental_calibration_vision/manifest.xml
@@ -5,7 +5,7 @@
 
   </description>
   <author>Jerome Maye</author>
-  <license>LGPL</license>
+  <license>3-Clause BSD</license>
   <review status="unreviewed" notes=""/>
   <url>https://github.com/ethz-asl/aslam_incremental_calibration</url>
 


### PR DESCRIPTION
The original switch was in 5f71f0f1ea120839e0442611cb965419312139fb
(Added / switched to 3-Clause BSD License). 

This is precisely removing all the remaining LGPL lines from many source files and switches license declaration in incremental_calibration_vision/manifest.xml. I only forgot to do that back then in 2017 when I switched to BSD as agreed upon with the original authors.
